### PR TITLE
fix(client): sanitize base_url by trimming trailing slashes

### DIFF
--- a/crates/liter-llm/src/client/config.rs
+++ b/crates/liter-llm/src/client/config.rs
@@ -222,8 +222,12 @@ impl ClientConfigBuilder {
     }
 
     /// Override the provider base URL for all requests.
+    ///
+    /// The URL is automatically sanitized to remove any trailing slashes to
+    /// ensure correct request path construction.
     pub fn base_url(mut self, url: impl Into<String>) -> Self {
-        self.config.base_url = Some(url.into());
+        let url = url.into();
+        self.config.base_url = Some(url.trim_end_matches('/').to_string());
         self
     }
 

--- a/crates/liter-llm/src/tests.rs
+++ b/crates/liter-llm/src/tests.rs
@@ -1429,3 +1429,26 @@ mod sse_tests {
         assert!(parse_sse_line("data:[DONE]").is_none());
     }
 }
+
+#[cfg(test)]
+mod config_tests {
+    use crate::client::ClientConfigBuilder;
+
+    #[test]
+    fn base_url_sanitization() {
+        // Test trailing slash removal
+        let builder = ClientConfigBuilder::new("key").base_url("https://api.example.com/");
+        let config = builder.build();
+        assert_eq!(config.base_url.unwrap(), "https://api.example.com");
+
+        // Test multiple trailing slashes
+        let builder = ClientConfigBuilder::new("key").base_url("https://api.example.com///");
+        let config = builder.build();
+        assert_eq!(config.base_url.unwrap(), "https://api.example.com");
+
+        // Test no trailing slash (remains unchanged)
+        let builder = ClientConfigBuilder::new("key").base_url("https://api.example.com");
+        let config = builder.build();
+        assert_eq!(config.base_url.unwrap(), "https://api.example.com");
+    }
+}


### PR DESCRIPTION
This PR addresses a path-construction bug where a `base_url` provided with a trailing slash caused malformed request URLs.  Initially reported [here](https://github.com/kreuzberg-dev/kreuzberg/issues/944)

**Changes:**
- **`ClientConfigBuilder::base_url`**: Now applies `.trim_end_matches('/')` to the input string before storage.
- **Unit Tests**: Added `config_tests::base_url_sanitization` to verify normalization for single, multiple, and zero trailing slashes.

**Verification:**
- Ran `cargo test -p liter-llm --lib config_tests` (Passed).
