### PR TITLE
docs(nav): add `ecosystem` page cross-linking the sibling docs sites

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,9 @@
+# Kreuzberg Ecosystem
+
+liter-llm is a universal LLM API client for 140+ providers, with bindings across languages. It's part of the Kreuzberg family — a set of open-source tools from the same team, each built on a fast Rust core. Explore the related projects:
+
+- **[Kreuzberg](https://docs.kreuzberg.dev/)** — an open-source document intelligence framework with a Rust core and bindings for many languages.
+- **[Kreuzberg Cloud](https://docs.kreuzberg.cloud/)** — managed document extraction for AI pipelines: a REST API, official SDKs (Python, TypeScript, Go, Dart), webhooks, and a no-signup sandbox.
+- **[html-to-markdown](https://docs.html-to-markdown.kreuzberg.dev/)** — a high-performance, CommonMark-compliant HTML → Markdown converter.
+- **[tree-sitter-language-pack](https://docs.tree-sitter-language-pack.kreuzberg.dev/)** — 300+ tree-sitter parsers with code intelligence and chunking.
+- **[Kreuzcrawl](https://docs.kreuzcrawl.kreuzberg.dev/)** — a high-performance web crawling engine with bindings for 11 languages.

--- a/zensical.toml
+++ b/zensical.toml
@@ -74,6 +74,8 @@ nav = [
     { "Contributing" = "contributing.md" },
     { "Changelog" = "CHANGELOG.md" },
   ] },
+
+  { "Ecosystem" = "ecosystem.md" },
 ]
 
 [project.theme]


### PR DESCRIPTION
Adds an on-site **Ecosystem** page (linked from the nav) describing and linking the related Kreuzberg-team docs sites, forming a hub-and-spoke mesh that aids crawl discovery and passes authority to the newer subdomains.

- Page-only nav: clicking **Ecosystem** opens the overview page (no external links in the sidebar).
- The owner site is excluded from its own list; descriptions verified against each project's docs.

**Post-deploy:** the page serves at `<site>/ecosystem/` — in the sitemap, self-canonical, indexable. Part of the cross-site Search Console cleanup.
